### PR TITLE
correct version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chainlift/liftkit-css",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chainlift/liftkit-css",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "GPL-3.0-or-later"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlift/liftkit-css",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "LiftKit is the golden framework for clean, minimal designs. Vanilla CSS framework built with M3 dynamic color, optically-kerned type, and Chainlift's one-of-a-kind golden ratio spacing. ",
   "main": "index.css",
   "scripts": {


### PR DESCRIPTION
- Changed container class names to match those in [LiftKit Docs](https://www.chainlift.io/liftkitdocs/containers). They were mistakenly using tailwind-like syntax which was an artifact leftover from dev on an upcoming tailwind plugin.